### PR TITLE
Integrate detect-secrets with Husky pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+detect-secrets-launcher components/* infra/* pages/* tests/*

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "commitizen": "4.3.0",
     "concurrently": "^8.2.2",
     "cz-conventional-changelog": "^3.3.0",
+    "detect-secrets": "^1.0.6",
     "eslint-config-next": "14.2.4",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jest": "^28.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       cz-conventional-changelog:
         specifier: ^3.3.0
         version: 3.3.0(@types/node@24.1.0)(typescript@5.8.3)
+      detect-secrets:
+        specifier: ^1.0.6
+        version: 1.0.6
       eslint-config-next:
         specifier: 14.2.4
         version: 14.2.4(eslint@8.57.0)(typescript@5.8.3)
@@ -1224,6 +1227,11 @@ packages:
   detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
+
+  detect-secrets@1.0.6:
+    resolution: {integrity: sha512-bAEmXtMJNS/By/TCg9uSW9Sp0V1Z0N+uwlQWFUMbCVri5Yq5rM8gVs+2zzNIjNOy36o5kANZRrMc+22Zf6eRFQ==}
+    engines: {node: '>=8.0.0'}
+    hasBin: true
 
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
@@ -4461,6 +4469,13 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-newline@3.1.0: {}
+
+  detect-secrets@1.0.6:
+    dependencies:
+      debug: 4.4.1
+      which: 1.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   diff-sequences@29.6.3: {}
 


### PR DESCRIPTION
This pull request introduces the integration of `detect-secrets` to the project and configures it to run as part of the Husky pre-commit hook. This ensures that any potential secrets are identified before committing code, enhancing security and reducing risks associated with accidental exposure.